### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -136,7 +136,7 @@ jobs:
         run: cargo tarpaulin --out Html
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: coverage-report
           path: ./tarpaulin-report.html


### PR DESCRIPTION
Bump GitHub Actions versions
  ```diff
  diff --git a/.github/workflows/core.yml b/.github/workflows/core.yml
index 0f9bbce..8c25c92 100644
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -136,7 +136,7 @@ jobs:
         run: cargo tarpaulin --out Html
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: coverage-report
           path: ./tarpaulin-report.html
  ```