### PR TITLE
cleanup flatten parameter types

### DIFF
--- a/delta/src/neuralnet/layers/flatten.rs
+++ b/delta/src/neuralnet/layers/flatten.rs
@@ -50,8 +50,8 @@ impl Flatten {
     /// # Returns
     ///
     /// A new instance of the flatten layer.
-    pub fn new(input_shape: Shape<IxDyn>) -> Self {
-        Self { name: "Flatten".to_string(), input_shape }
+    pub fn new(input_shape: &[usize]) -> Self {
+        Self { name: "Flatten".to_string(), input_shape: Shape::from(IxDyn(&input_shape)) }
     }
 }
 
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_flatten_new() {
         let input_shape = Shape::from(IxDyn(&[28, 28]));
-        let flatten_layer = Flatten::new(input_shape.clone());
+        let flatten_layer = Flatten::new(&[28, 28]);
 
         assert_eq!(flatten_layer.name(), "Flatten");
         assert_eq!(flatten_layer.input_shape.raw_dim(), input_shape.raw_dim());
@@ -172,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_flatten_output_shape() {
-        let input_shape = Shape::from(IxDyn(&[3, 4]));
-        let flatten_layer = Flatten::new(input_shape.clone());
+        let flatten_layer = Flatten::new(&[3, 4]);
 
         let output_shape = flatten_layer.output_shape().unwrap();
         assert_eq!(output_shape.raw_dim().as_array_view().to_vec(), vec![12]);
@@ -181,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_flatten_param_count() {
-        let flatten_layer = Flatten::new(Shape::from(IxDyn(&[10, 10])));
+        let flatten_layer = Flatten::new(&[10, 10]);
         let (trainable, non_trainable) = flatten_layer.param_count().unwrap();
 
         assert_eq!(trainable, 0);

--- a/delta/src/neuralnet/mod.rs
+++ b/delta/src/neuralnet/mod.rs
@@ -31,7 +31,7 @@ pub mod layers;
 pub mod models;
 
 // used for operations on Tensors
-pub mod functional; 
+pub mod functional;
 
 pub use layers::{Dense, Flatten};
 pub use models::Sequential;
@@ -39,8 +39,6 @@ pub use models::Sequential;
 /// Putting tests here since it's using a collection of everything
 #[cfg(test)]
 mod tests {
-    use ndarray::{IxDyn, Shape};
-
     use crate::activations::{ReluActivation, SoftmaxActivation};
     use crate::losses::MeanSquaredLoss;
     use crate::neuralnet::{Dense, Flatten, Sequential};
@@ -48,7 +46,7 @@ mod tests {
 
     fn create_sequential_model() -> Sequential {
         Sequential::new()
-            .add(Flatten::new(Shape::from(IxDyn(&[28, 28]))))
+            .add(Flatten::new(&[28, 28]))
             .add(Dense::new(128, Some(ReluActivation::new()), true))
             .add(Dense::new(10, None::<SoftmaxActivation>, false))
     }

--- a/examples/image_classification/cifar10/Cargo.toml
+++ b/examples/image_classification/cifar10/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 deltaml = { path = "../../../delta" }
 tokio = { workspace = true, features = ["full"] }
+
+[features]
+default = []
+metal = ["deltaml/metal"]

--- a/examples/image_classification/cifar10/src/main.rs
+++ b/examples/image_classification/cifar10/src/main.rs
@@ -1,5 +1,4 @@
 use deltaml::activations::{ReluActivation, SoftmaxActivation};
-use deltaml::common::ndarray::{IxDyn, Shape};
 use deltaml::dataset::Cifar10Dataset;
 use deltaml::dataset::base::ImageDatasetOps;
 use deltaml::losses::MeanSquaredLoss;
@@ -10,7 +9,7 @@ use deltaml::optimizers::Adam;
 async fn main() {
     // Create a neural network
     let mut model = Sequential::new()
-        .add(Flatten::new(Shape::from(IxDyn(&[32, 32, 3])))) // CIFAR-10: 32x32x3 -> 3072
+        .add(Flatten::new(&[32, 32, 3])) // CIFAR-10: 32x32x3 -> 3072
         .add(Dense::new(128, Some(ReluActivation::new()), true)) // Input: 3072, Output: 128
         .add(Dense::new(10, Some(SoftmaxActivation::new()), false)); // Output: 10 classes
 
@@ -49,7 +48,8 @@ async fn main() {
     }
 
     // Evaluate the model
-    let accuracy = model.evaluate(&mut test_data, batch_size).expect("Failed to evaluate the model");
+    let accuracy =
+        model.evaluate(&mut test_data, batch_size).expect("Failed to evaluate the model");
     println!("Test Accuracy: {:.2}%", accuracy * 100.0);
 
     // Save the model

--- a/examples/image_classification/cifar100/Cargo.toml
+++ b/examples/image_classification/cifar100/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 deltaml = { path = "../../../delta" }
 tokio = { workspace = true, features = ["full"] }
+
+[features]
+default = []
+metal = ["deltaml/metal"]

--- a/examples/image_classification/cifar100/src/main.rs
+++ b/examples/image_classification/cifar100/src/main.rs
@@ -1,5 +1,4 @@
 use deltaml::activations::{ReluActivation, SoftmaxActivation};
-use deltaml::common::ndarray::{IxDyn, Shape};
 use deltaml::dataset::base::ImageDatasetOps;
 use deltaml::dataset::image::Cifar100Dataset;
 use deltaml::losses::MeanSquaredLoss;
@@ -10,7 +9,7 @@ use deltaml::optimizers::Adam;
 async fn main() {
     // Create a neural network
     let mut model = Sequential::new()
-        .add(Flatten::new(Shape::from(IxDyn(&[32, 32, 3])))) // CIFAR-100: 32x32x3 -> 3072
+        .add(Flatten::new(&[32, 32, 3])) // CIFAR-100: 32x32x3 -> 3072
         .add(Dense::new(128, Some(ReluActivation::new()), true)) // Input: 3072, Output: 128
         .add(Dense::new(100, Some(SoftmaxActivation::new()), false)); // Output: 100 classes
 
@@ -49,7 +48,8 @@ async fn main() {
     }
 
     // Evaluate the model
-    let accuracy = model.evaluate(&mut test_data, batch_size).expect("Failed to evaluate the model");
+    let accuracy =
+        model.evaluate(&mut test_data, batch_size).expect("Failed to evaluate the model");
     println!("Test Accuracy: {:.2}%", accuracy * 100.0);
 
     // Save the model

--- a/examples/image_classification/imagenet_v2/Cargo.toml
+++ b/examples/image_classification/imagenet_v2/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 deltaml = { path = "../../../delta" }
 tokio = { workspace = true, features = ["full"] }
+
+[features]
+default = []
+metal = ["deltaml/metal"]

--- a/examples/image_classification/imagenet_v2/src/main.rs
+++ b/examples/image_classification/imagenet_v2/src/main.rs
@@ -1,6 +1,5 @@
 use deltaml::activations::relu::ReluActivation;
 use deltaml::activations::softmax::SoftmaxActivation;
-use deltaml::common::ndarray::{IxDyn, Shape};
 use deltaml::dataset::ImageNetV2Dataset;
 use deltaml::dataset::base::ImageDatasetOps;
 use deltaml::losses::SparseCategoricalCrossEntropyLoss;
@@ -11,7 +10,7 @@ use deltaml::optimizers::Adam;
 async fn main() {
     // Create a neural network
     let mut model = Sequential::new()
-        .add(Flatten::new(Shape::from(IxDyn(&[224, 224, 3])))) // Input: 224x224x3 (ImageNet images)
+        .add(Flatten::new(&[224, 224, 3])) // Input: 224x224x3 (ImageNet images)
         .add(Dense::new(512, Some(ReluActivation::new()), true)) // Hidden layer: 512 units
         .add(Dense::new(256, Some(ReluActivation::new()), true)) // Hidden layer: 256 units
         .add(Dense::new(1000, None::<SoftmaxActivation>, false)); // Output: 1000 classes (ImageNet categories)

--- a/examples/image_classification/mnist/src/main.rs
+++ b/examples/image_classification/mnist/src/main.rs
@@ -1,5 +1,4 @@
 use deltaml::activations::{ReluActivation, SoftmaxActivation};
-use deltaml::common::ndarray::{IxDyn, Shape};
 use deltaml::dataset::{ImageDatasetOps, MnistDataset};
 use deltaml::losses::SparseCategoricalCrossEntropyLoss;
 use deltaml::neuralnet::{Dense, Flatten, Sequential};
@@ -11,7 +10,7 @@ async fn main() {
     let mut model = Sequential::new()
         // .add(Conv2D::new(32, 3, 1, 1, Some(Box::new(ReluActivation::new())), true)) // Conv2D layer with 32 filters, kernel size 3x3
         // .add(MaxPooling2D::new(2, 2)) // MaxPooling2D layer with pool size 2x2
-        .add(Flatten::new(Shape::from(IxDyn(&[28, 28])))) // Flatten layer
+        .add(Flatten::new(&[28, 28])) // Flatten layer
         .add(Dense::new(128, Some(ReluActivation::new()), true)) // Dense layer with 128 units
         .add(Dense::new(10, None::<SoftmaxActivation>, false)); // Output layer with 10 classes
 


### PR DESCRIPTION
This simplifies the Flatten::new params to remove the ndarray.

```rust
let mut model = Sequential::new()
        .add(Flatten::new(&[32, 32, 3])) // CIFAR-10: 32x32x3 -> 3072
        .add(Dense::new(128, Some(ReluActivation::new()), true)) // Input: 3072, Output: 128
        .add(Dense::new(10, Some(SoftmaxActivation::new()), false)); // Output: 10 classes
```