### PR TITLE
fix[cargo]: warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,29 @@ members = [
     "examples/deep_learning/imagenet_v2",
     "examples/classical_ml/linear_regression",
     "examples/classical_ml/logistic_regression",
-
 ]
 resolver = "2"
 
 [workspace.dependencies]
 tokio = { version = "1.32.0", features = ["full"] }
 
-[workspace.dev-dependencies]
-flamegraph = "0.6.6"
+
+[profile.dev]
+opt-level = 0
+debug = true
+panic = "abort"
+
+[profile.test]
+opt-level = 0
+debug = true
+
+[profile.release]
+opt-level = 3
+debug = false
+panic = "unwind"
+lto = true
+codegen-units = 1
+
+[profile.bench]
+opt-level = 3
+debug = false

--- a/delta/Cargo.toml
+++ b/delta/Cargo.toml
@@ -48,22 +48,5 @@ deep_learning = []
 vision = ["deep_learning"]
 metal = ["dep:metal"]
 
-[profile.dev]
-opt-level = 0
-debug = true
-panic = "abort"
-
-[profile.test]
-opt-level = 0
-debug = true
-
-[profile.release]
-opt-level = 3
-debug = false
-panic = "unwind"
-lto = true
-codegen-units = 1
-
-[profile.bench]
-opt-level = 3
-debug = false
+[dev-dependencies]
+flamegraph = "0.6.6"


### PR DESCRIPTION
This PR fixes these cargo warnings 

> warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/ubuntu/delta/delta/Cargo.toml
workspace: /home/ubuntu/delta/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/ubuntu/delta/delta/Cargo.toml
workspace: /home/ubuntu/delta/Cargo.toml
warning: /home/ubuntu/delta/Cargo.toml: unused manifest key: workspace.dev-dependencies